### PR TITLE
on Debian bullseye install python3-passlib instead of python-passlib

### DIFF
--- a/tasks/install/Debian.bullseye.yml
+++ b/tasks/install/Debian.bullseye.yml
@@ -1,0 +1,8 @@
+---
+- name: install apache2
+  apt:
+    pkg:
+      - apache2
+      - python3-passlib
+    state: present
+    update_cache: no


### PR DESCRIPTION
This PR fixes: Using this ansible role on Debian11

It is just a tiny variation of the default https://github.com/programmfabrik/role-apache2/blob/f825bd3af21ab4bb063a10241e771c0276ccb3a2/tasks/install/default.yml